### PR TITLE
Create only one nifti

### DIFF
--- a/nekton/dcm2nii.py
+++ b/nekton/dcm2nii.py
@@ -16,6 +16,10 @@ class Dcm2Nii(BaseConverter):
     def __init__(self):
         make_exec_bin()
         self.run_bin = run_bin
+        """ 
+        merge flag:  -m : merge 2D slices from same series regardless of echo, exposure, etc. (n/y or 0/1/2, default 2) [no, yes, auto]
+        ignore flag: -i : ignore derived, localizer and 2D images (y/n, default n)
+        """
         self.ignore_flag = "n"
         self.merge_flag = "2"
         super().__init__()

--- a/nekton/dcm2nii.py
+++ b/nekton/dcm2nii.py
@@ -69,7 +69,7 @@ class Dcm2Nii(BaseConverter):
         )
         return False if len(all_slice_thickness) == 1 else True
 
-    def _run_conv_variable(self, dicom_directory: Path, out_directory: Path) -> List[Path]:
+    def _run_conv_variable(self, dicom_directory: Path, out_directory: Path, ignore_flag:bool= False) -> List[Path]:
         raise NotImplementedError(
             "DICOM with variable slice thickness cannot to be handled yet!!"
         )
@@ -107,7 +107,7 @@ class Dcm2Nii(BaseConverter):
             out_file_list.append(rename_file(str(file_path), fname))
         return out_file_list
 
-    def _run_conv_uniform(self, dicom_directory: Path, out_directory:Path,ignore_flag:bool) -> List[Path]:
+    def _run_conv_uniform(self, dicom_directory: Path, out_directory:Path,ignore_flag:bool= False) -> List[Path]:
         """run the binary on the input directory
 
         Args:
@@ -122,7 +122,7 @@ class Dcm2Nii(BaseConverter):
         output_files = list(Path(dicom_directory).glob("*.nii*"))
         return output_files
 
-    def run(self, dicom_directory: Path, out_directory:Path=None, name: str = "",ignore_flag: bool=None) -> List[Path]:
+    def run(self, dicom_directory: Path, out_directory:Path=None, name: str = "",ignore_flag: bool=False) -> List[Path]:
         """Run the dcm to nifti conversion in a directory
 
         Args:

--- a/nekton/dcm2nii.py
+++ b/nekton/dcm2nii.py
@@ -16,6 +16,8 @@ class Dcm2Nii(BaseConverter):
     def __init__(self):
         make_exec_bin()
         self.run_bin = run_bin
+        self.ignore_flag = "n"
+        self.merge_flag = "2"
         super().__init__()
 
     @staticmethod
@@ -69,7 +71,7 @@ class Dcm2Nii(BaseConverter):
         )
         return False if len(all_slice_thickness) == 1 else True
 
-    def _run_conv_variable(self, dicom_directory: Path, out_directory: Path, ignore_flag:bool= False) -> List[Path]:
+    def _run_conv_variable(self, dicom_directory: Path, out_directory: Path) -> List[Path]:
         raise NotImplementedError(
             "DICOM with variable slice thickness cannot to be handled yet!!"
         )
@@ -107,7 +109,7 @@ class Dcm2Nii(BaseConverter):
             out_file_list.append(rename_file(str(file_path), fname))
         return out_file_list
 
-    def _run_conv_uniform(self, dicom_directory: Path, out_directory:Path,ignore_flag:bool= False) -> List[Path]:
+    def _run_conv_uniform(self, dicom_directory: Path, out_directory:Path) -> List[Path]:
         """run the binary on the input directory
 
         Args:
@@ -116,13 +118,13 @@ class Dcm2Nii(BaseConverter):
         Returns:
             List[Path]: output NifTi files post conversion
         """
-        self.run_bin(dicom_directory, out_directory,ignore_flag)
+        self.run_bin(dicom_directory, out_directory,self.ignore_flag,self.merge_flag)
         if out_directory is not None:
             dicom_directory = out_directory
         output_files = list(Path(dicom_directory).glob("*.nii*"))
         return output_files
 
-    def run(self, dicom_directory: Path, out_directory:Path=None, name: str = "",ignore_flag: bool=False) -> List[Path]:
+    def run(self, dicom_directory: Path, out_directory:Path=None, name: str = "") -> List[Path]:
         """Run the dcm to nifti conversion in a directory
 
         Args:
@@ -145,9 +147,9 @@ class Dcm2Nii(BaseConverter):
 
         try:
             if self.check_slice_thickness_variable(all_dcm_paths):
-                converted_file_paths = self._run_conv_variable(dicom_directory, out_directory,ignore_flag)
+                converted_file_paths = self._run_conv_variable(dicom_directory, out_directory)
             else:
-                converted_file_paths = self._run_conv_uniform(dicom_directory, out_directory,ignore_flag)
+                converted_file_paths = self._run_conv_uniform(dicom_directory, out_directory)
         except Exception as err:
             raise RuntimeError(f"Error converting DCM to NifTi: {err}")
 

--- a/nekton/dcm2nii.py
+++ b/nekton/dcm2nii.py
@@ -107,7 +107,7 @@ class Dcm2Nii(BaseConverter):
             out_file_list.append(rename_file(str(file_path), fname))
         return out_file_list
 
-    def _run_conv_uniform(self, dicom_directory: Path, out_directory:Path) -> List[Path]:
+    def _run_conv_uniform(self, dicom_directory: Path, out_directory:Path,ignore_flag:bool) -> List[Path]:
         """run the binary on the input directory
 
         Args:
@@ -116,13 +116,13 @@ class Dcm2Nii(BaseConverter):
         Returns:
             List[Path]: output NifTi files post conversion
         """
-        self.run_bin(dicom_directory, out_directory)
+        self.run_bin(dicom_directory, out_directory,ignore_flag)
         if out_directory is not None:
             dicom_directory = out_directory
         output_files = list(Path(dicom_directory).glob("*.nii*"))
         return output_files
 
-    def run(self, dicom_directory: Path, out_directory:Path=None, name: str = "") -> List[Path]:
+    def run(self, dicom_directory: Path, out_directory:Path=None, name: str = "",ignore_flag: bool=None) -> List[Path]:
         """Run the dcm to nifti conversion in a directory
 
         Args:
@@ -145,9 +145,9 @@ class Dcm2Nii(BaseConverter):
 
         try:
             if self.check_slice_thickness_variable(all_dcm_paths):
-                converted_file_paths = self._run_conv_variable(dicom_directory, out_directory)
+                converted_file_paths = self._run_conv_variable(dicom_directory, out_directory,ignore_flag)
             else:
-                converted_file_paths = self._run_conv_uniform(dicom_directory, out_directory)
+                converted_file_paths = self._run_conv_uniform(dicom_directory, out_directory,ignore_flag)
         except Exception as err:
             raise RuntimeError(f"Error converting DCM to NifTi: {err}")
 

--- a/nekton/utils/bin.py
+++ b/nekton/utils/bin.py
@@ -19,33 +19,21 @@ def make_exec_bin():
     process.communicate()
 
 
-def run_bin(path: str, outpath:str = None,ignore_flag:bool = False):
+def run_bin(path: str, outpath:str = None,ignore_flag:str = None,merge_flag:str = None):
     """run the binary on a given directory
 
     Args:
         path ([str]): directory where dicom exists
     """
-    if outpath is None and ignore_flag is False:
+    if outpath is None:
         process = subprocess.Popen(
-            [PATH_TO_BIN, "-z","y","-m","1", path],
-            stdout=subprocess.PIPE,
-            universal_newlines=True,
-        )
-    elif outpath is None and ignore_flag is True:
-        process = subprocess.Popen(
-            [PATH_TO_BIN, "-z","y","-m","1","-i","y", path],
-            stdout=subprocess.PIPE,
-            universal_newlines=True,
-        )
-    elif outpath is not None and ignore_flag is False:
-        process = subprocess.Popen(
-            [PATH_TO_BIN, "-z","y","-m","1","-o", outpath, path],
+            [PATH_TO_BIN, "-z","y","-m",merge_flag,"-i",ignore_flag, path],
             stdout=subprocess.PIPE,
             universal_newlines=True,
         )
     else:
         process = subprocess.Popen(
-            [PATH_TO_BIN, "-z","y","-m","1","-i","y","-o", outpath, path],
+            [PATH_TO_BIN, "-z","y","-m",merge_flag,"-i",ignore_flag,"-o", outpath, path],
             stdout=subprocess.PIPE,
             universal_newlines=True,
         )

--- a/nekton/utils/bin.py
+++ b/nekton/utils/bin.py
@@ -27,25 +27,25 @@ def run_bin(path: str, outpath:str = None,ignore_flag:bool = False):
     """
     if outpath is None and ignore_flag is False:
         process = subprocess.Popen(
-            [PATH_TO_BIN, "-z", "y", path],
+            [PATH_TO_BIN, "-z","y","-m","1", path],
             stdout=subprocess.PIPE,
             universal_newlines=True,
         )
     elif outpath is None and ignore_flag is True:
         process = subprocess.Popen(
-            [PATH_TO_BIN, "-z", "y","-i","y", path],
+            [PATH_TO_BIN, "-z","y","-m","1","-i","y", path],
             stdout=subprocess.PIPE,
             universal_newlines=True,
         )
     elif outpath is not None and ignore_flag is False:
         process = subprocess.Popen(
-            [PATH_TO_BIN, "-z", "y","-o", outpath, path],
+            [PATH_TO_BIN, "-z","y","-m","1","-o", outpath, path],
             stdout=subprocess.PIPE,
             universal_newlines=True,
         )
     else:
         process = subprocess.Popen(
-            [PATH_TO_BIN, "-z", "y","-i","y","-o", outpath, path],
+            [PATH_TO_BIN, "-z","y","-m","1","-i","y","-o", outpath, path],
             stdout=subprocess.PIPE,
             universal_newlines=True,
         )

--- a/nekton/utils/bin.py
+++ b/nekton/utils/bin.py
@@ -1,3 +1,4 @@
+#!/bin/sh
 import subprocess
 import os
 
@@ -18,21 +19,33 @@ def make_exec_bin():
     process.communicate()
 
 
-def run_bin(path: str, outpath:str = None):
+def run_bin(path: str, outpath:str = None,ignore_flag:bool = False):
     """run the binary on a given directory
 
     Args:
         path ([str]): directory where dicom exists
     """
-    if outpath is None:
+    if outpath is None and ignore_flag is False:
         process = subprocess.Popen(
             [PATH_TO_BIN, "-z", "y", path],
             stdout=subprocess.PIPE,
             universal_newlines=True,
         )
-    else:
+    elif outpath is None and ignore_flag is True:
+        process = subprocess.Popen(
+            [PATH_TO_BIN, "-z", "y","-i","y", path],
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+        )
+    elif outpath is not None and ignore_flag is False:
         process = subprocess.Popen(
             [PATH_TO_BIN, "-z", "y","-o", outpath, path],
+            stdout=subprocess.PIPE,
+            universal_newlines=True,
+        )
+    else:
+        process = subprocess.Popen(
+            [PATH_TO_BIN, "-z", "y","-i","y","-o", outpath, path],
             stdout=subprocess.PIPE,
             universal_newlines=True,
         )

--- a/nekton/utils/bin.py
+++ b/nekton/utils/bin.py
@@ -19,7 +19,7 @@ def make_exec_bin():
     process.communicate()
 
 
-def run_bin(path: str, outpath:str = None,ignore_flag:str = None,merge_flag:str = None):
+def run_bin(path: str, outpath:str = None,ignore_flag:str = "n",merge_flag:str = "2"):
     """run the binary on a given directory
 
     Args:


### PR DESCRIPTION
To avoid creating multiple nifti files for single series, I added -m flag. Explanation:
  -m : merge 2D slices from same series regardless of echo, exposure, etc. (n/y or 0/1/2, default 2) [no, yes, auto]
